### PR TITLE
Adding the ability for bot to generate a DLabs Google Hangout URL.

### DIFF
--- a/scripts/ghangout.coffee
+++ b/scripts/ghangout.coffee
@@ -27,13 +27,12 @@ defaultRooms = [
 ]
 
 module.exports = (robot) ->
-	robot.respond /(?:ghangout|ghang)(?: me)?\s(.*)/i, (msg) ->
+	robot.respond /(?:ghangout|ghang)(?: me)?(.*)/i, (msg) ->
 		roomName = msg.match[1]
+		roomName = parseRoomName(roomName)	
 
-		if roomName in ["random","rand"]
+		if roomName.toLowerCase() in ["random","rand"]
 			roomName = msg.random defaultRooms
-
-		roomName = parseRoomName(roomName)
 
 		if not roomName.length
 			roomName = parseRoomName(msg.envelope.room)


### PR DESCRIPTION
This will allow anyone to quickly create a link that can be used to create a new (or join an existing with the same name) Google Hangout under the Detroit Labs enterprise setup. It also gives you what name to enter into a chrome box to open said hangout. Yay.

Only users with @detroitlabs.com google accounts can join said hangouts, so it's not useful for clients/outsiders.

Also, this is the first batch of coffeescript, so critque away.
