### PR TITLE
Added a challenge tracking script for Hubot

### DIFF
--- a/scripts/challenge.coffee
+++ b/scripts/challenge.coffee
@@ -1,0 +1,46 @@
+# Description:
+#   Have hubot keep track of and display challenge leaderboard
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   hubot <type> challenge
+#   hubot <type> challenge set <who>:<count>
+#   
+# Author:
+#   laurenmalatesta
+
+
+createKey = (type) ->
+  "challenge_" + type
+
+
+challengeStatus = (msg, key) ->
+  challenge = msg.robot.brain.get key
+
+  "The #{challenge.type} challenge leader is #{challenge.who} at #{challenge.count}."
+
+
+module.exports = (robot) ->
+  
+  robot.respond /(.+) challenge set (.+):(\d+)/i, (msg) ->
+    challenge = 
+      type:  msg.match[1]
+      who:   msg.match[2]
+      count: msg.match[3]
+
+    key = createKey challenge.type
+
+    msg.robot.brain.set key, challenge
+    
+    msg.send challengeStatus msg, key
+
+  
+  robot.respond /(.+) challenge$/i, (msg) ->
+    key = createKey msg.match[1]
+
+    msg.send challengeStatus msg, key


### PR DESCRIPTION
I made a script that can take Detroit Labs challenge data input and spit it back out upon request. Never again wonder who is leading the Taco challenge.
