### PR TITLE
latest hipchat supports blacklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "hubot": ">= 2.6.0 < 3.0.0",
     "hubot-scripts": "2.5.8",
-    "hubot-hipchat": "git://github.com/maschall/hubot-hipchat.git#exclude-rooms",
+    "hubot-hipchat": ">= 2.7.5",
     "request": "~2.25.0",
     "hipchatter": "~0.1",
     "googlemaps": "0.1.9",


### PR DESCRIPTION
They merged in my PR for supporting blacklist rooms, so might as well change back to the official package

The config name changed, and I just copied the original config to the new name 
