### PR TITLE
ADDED redlight script that has a dependency on the MQTT module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,20 +20,21 @@
     "url": "https://github.com/github/hubot.git"
   },
   "dependencies": {
-    "hubot": "2.11.0",
-    "hubot-scripts": "2.5.16",
-    "hubot-hipchat": "2.7.5",
-    "request": "~2.51",
-    "hipchatter": "~0.1",
-    "googlemaps": "0.1.20",
     "cool-ascii-faces": "1.3.3",
-    "underscore": "1.7.0",
     "datejs": "1.0.0-rc3",
-    "nodemailer": "1.3.0",
-    "hubot-cron": "0.2.7",
     "github": "0.2.3",
+    "googlemaps": "0.1.20",
+    "hipchatter": "~0.1",
+    "hubot": "2.11.0",
+    "hubot-cron": "0.2.7",
+    "hubot-hipchat": "2.7.5",
+    "hubot-scripts": "2.5.16",
+    "moment": "2.9.0",
+    "mqtt": "^1.0.10",
+    "nodemailer": "1.3.0",
     "promise": "6.1.0",
-    "moment": "2.9.0"
+    "request": "~2.51",
+    "underscore": "1.7.0"
   },
   "engines": {
     "node": "0.10.30",

--- a/scripts/redlight.coffee
+++ b/scripts/redlight.coffee
@@ -8,7 +8,7 @@
 #
 # Commands:
 #
-#   .redlight - toggles the state of the redlight
+# hubot redlight - toggles the state of the redlight
 #
 
 topic = "toggle/red_alert"

--- a/scripts/redlight.coffee
+++ b/scripts/redlight.coffee
@@ -1,0 +1,21 @@
+# Description:
+#   Turns the red siren light on or off
+#
+# Dependencies:
+#   mqtt
+#
+# Configuration:
+#
+# Commands:
+#
+#   .redlight - toggles the state of the redlight
+#
+
+topic = "toggle/red_alert"
+mqtt = require("mqtt")
+client = mqtt.connect('mqtt://broadsidetv.com')
+lightActive = false
+
+module.exports = (robot) ->
+  robot.respond /redlight/i, (msg) ->
+      client.publish topic


### PR DESCRIPTION
The relight module is a script that will enable the bot to toggle a Red Alert ight on and off by using the MQTT data broker running on broadsidetv.com