### PR TITLE
fix license warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register tests"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/github/hubot/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/github/hubot.git"


### PR DESCRIPTION
Running `npm install` yielded the following warning:

    npm WARN package.json hosted-hubot@2.8.0 No license field.

According to https://docs.npmjs.com/files/package.json#license, the
“licenses” object has been deprecated in favor of “license.”