### PR TITLE
remove emoji.coffee

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -18,7 +18,6 @@
   "disassemble.coffee",
   "eight-ball.coffee",
   "lmgtfy.coffee",
-  "emoji.coffee",
   "achievement_unlocked.coffee",
   "fortune.coffee",
   "bookmark.coffee"


### PR DESCRIPTION
[source](https://github.com/github/hubot-scripts/blob/master/src/scripts/emoji.coffee)

With Slack, we no longer need to put a :bird: on it.