### PR TITLE
ML : Adding funny image URL for Matt Lauer suggestion

### DIFF
--- a/scripts/chowning.coffee
+++ b/scripts/chowning.coffee
@@ -14,7 +14,7 @@
 
 suggestions = [
   "Did you mean Matt Tyndall?",
-  "Maybe you meant Matt Lauer.",
+  "http://i.imgur.com/NWNHh1e.png Maybe you meant Matt Lauer.",
   "Hypothetically, of course."
 ]
 


### PR DESCRIPTION
Adding a funny image URL to post when the Matt Lauer suggestion of the Chowining script runs. This crossing out of "Chowning" really happened in JIRA.

I tested this out in Slack using get/set with Hal. When the imgur link posts as a message, the image appears (upon first run) above "Maybe you meant Matt Lauer." Seems to achieve the desired effect.
<img width="463" alt="chowningtest" src="https://cloud.githubusercontent.com/assets/8700989/13156093/ce72e536-d64e-11e5-9f88-a8dcf568f9a0.png">

See attached. See also the imgur link: http://i.imgur.com/NWNHh1e.png
![maybeyoumeant](https://cloud.githubusercontent.com/assets/8700989/13155905/0c491494-d64e-11e5-9d6e-df4cb8d441eb.png)

![bitmoji](https://render.bitstrips.com/v2/cpanel/9163561-125456932_1-s1-v1.png?palette=1&width=246)