### PR TITLE
Device Status

### DIFF
--- a/scripts/devices.coffee
+++ b/scripts/devices.coffee
@@ -1,0 +1,39 @@
+# Description:
+#   Returns the status of all testing device
+#
+# Dependencies:
+#   request
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   hubot devices
+#
+# Author:
+#   peike
+
+request = require 'request'
+
+formatMessage = (json) ->
+  getIcon = (platform) -> if platform is "ANDROID" then ":android:" else ""
+  getUser = (checkOutBy) -> if not checkOutBy then "" else " - #{checkOutBy}"
+  result = ""
+  for k,v of json
+    icon = getIcon v.platform
+    user = getUser v.checked_out_by
+    result += "#{icon} #{v.brand_and_model}, #{v.version}, #{v.screen_size}#{user}\n"
+  return result
+
+module.exports = (robot) ->
+  robot.respond /devices/i, (msg) ->
+    options =
+      method: 'GET'
+      uri: 'https://device-manager-c5b89.firebaseio.com/devices.json'
+      json: true
+    request options, (error, response, json) ->
+      { statusCode, statusMessage } = response
+      switch
+        when error then msg.send "Error: #{error.message}"
+        when statusCode is 200 then msg.send formatMessage json
+        when statusCode >= 300 then msg.send "#{statusCode} #{statusMessage}"


### PR DESCRIPTION
Add new slack command to retrieve the status of all the testing devices

Local testing:

```
Hubot> hubot devices
Hubot> :android: Android SDK Built For X86_64, 7.1.1, 4.6 in
:android: Emulated AndroidK Built For X86_64, 7.1.1, 5.2 in
:android: Nexus 5X, 7.0, 5.2 in
:android: LG G2, 4.4.2, 5.2 in
:android: Galaxy S6, 6.0.1, 5.1 in - google
:android: Galaxy S8, 7.0, 5.8 in
:android: Pixel, 7.1.1, 5.0 in
:android: LG G4, 5.1, 5.5 in - Roberto
:android: Nexus 6, 7.0, 6.0 in - Peike
```

Is this PR the only thing I need to do to make the `.devices` command work in Slack?

I'm not really good at CoffeeScript, so there must be a better and more concise way to format the result.

Thanks to the `tigers.coffee`. I copy a lot from there.



